### PR TITLE
CLS command implementation

### DIFF
--- a/BugChecker/BugChecker.vcxproj
+++ b/BugChecker/BugChecker.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="Cmd_BE.cpp" />
     <ClCompile Include="Cmd_BL.cpp" />
     <ClCompile Include="Cmd_BPX.cpp" />
+    <ClCompile Include="Cmd_CLS.cpp" />
     <ClCompile Include="Cmd_D.cpp" />
     <ClCompile Include="Cmd_E.cpp" />
     <ClCompile Include="Cmd_KL.cpp" />

--- a/BugChecker/Cmd_CLS.cpp
+++ b/BugChecker/Cmd_CLS.cpp
@@ -1,0 +1,32 @@
+#include "BugChecker.h"
+
+#include "Cmd.h"
+#include "Root.h"
+
+class Cmd_CLS : public Cmd
+{
+public:
+
+	virtual const CHAR* GetId() { return "CLS"; }
+	virtual const CHAR* GetDesc() { return "Clear log window."; }
+	virtual const CHAR* GetSyntax() { return "CLS (no parameters)"; }
+
+	virtual BcCoroutine Execute(CmdParams& params) noexcept
+	{
+		auto args = TokenizeArgs(params.cmd, "CLS");
+
+		if (args.size() != 1)
+		{
+			Print("Too many arguments.");
+			co_return;
+		}
+
+		Root::I->LogWindow.Clear();
+
+		Wnd::DrawAll_End();
+		Wnd::DrawAll_Final();
+		co_return;
+	}
+};
+
+REGISTER_COMMAND(Cmd_CLS)

--- a/BugChecker/LogWnd.cpp
+++ b/BugChecker/LogWnd.cpp
@@ -106,6 +106,8 @@ VOID LogWnd::AddString(const CHAR* psz, BOOLEAN doAppend /*= FALSE*/, BOOLEAN re
 VOID LogWnd::Clear()
 {
 	contents.clear();
+	allocSize = 0;
+	Home();
 }
 
 eastl::string LogWnd::GetLineToDraw(ULONG index)

--- a/BugChecker/LogWnd.cpp
+++ b/BugChecker/LogWnd.cpp
@@ -103,6 +103,11 @@ VOID LogWnd::AddString(const CHAR* psz, BOOLEAN doAppend /*= FALSE*/, BOOLEAN re
 	}
 }
 
+VOID LogWnd::Clear()
+{
+	contents.clear();
+}
+
 eastl::string LogWnd::GetLineToDraw(ULONG index)
 {
 	eastl::string s = contents[index];

--- a/BugChecker/LogWnd.cpp
+++ b/BugChecker/LogWnd.cpp
@@ -105,7 +105,7 @@ VOID LogWnd::AddString(const CHAR* psz, BOOLEAN doAppend /*= FALSE*/, BOOLEAN re
 
 VOID LogWnd::Clear()
 {
-	contents.clear();
+	eastl::vector<eastl::string>().swap(contents);
 	allocSize = 0;
 	Home();
 }

--- a/BugChecker/LogWnd.h
+++ b/BugChecker/LogWnd.h
@@ -10,6 +10,7 @@ public:
 
 	VOID AddUserCmd(const CHAR* psz);
 	VOID AddString(const CHAR* psz, BOOLEAN doAppend = FALSE, BOOLEAN refreshUi = FALSE);
+	VOID Clear();
 
 	VOID GoToEnd();
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The command name and syntax are chosen to be as close as possible to those of th
 * **BE list|***: Enable one or more breakpoints.
 * **BL (no parameters)**: List all breakpoints.
 * **BPX address [-t|-p] [WHEN js-expression]**: Set a breakpoint on execution.
+* **CLS (no parameters)**: Clear log window.
 * **DB/DW/DD/DQ [address] [-l len-in-bytes]**: Display memory as 8/16/32/64-bit values.
 * **EB/EW/ED/EQ address -v space-separated-values**: Edit memory as 8/16/32/64-bit values.
 * **KL EN|IT**: Set keyboard layout.


### PR DESCRIPTION
This PR implements the CLS command that, like in the original SoftICE, clears the commands/logs window.

Tested using a Windows 11 Pro VM (VMWare)