### PR TITLE
Resume execution on PrntSc key press

### DIFF
--- a/BugChecker/Main.cpp
+++ b/BugChecker/Main.cpp
@@ -510,6 +510,7 @@ BcCoroutine Main::EntryPoint() noexcept
 			break;
 
 			case MACRO_SCANCODE_F5:
+			case MACRO_SCANCODE_PrtSc:
 			{
 				co_await BcAwaiter_Join{ ProcessCmd(
 					eastl::pair<eastl::string, Cmd*>("X", GetCmd("X")),

--- a/BugChecker/Ps2Keyb.h
+++ b/BugChecker/Ps2Keyb.h
@@ -70,6 +70,7 @@ public:
 #define MACRO_SCANCODE_Slash  0x35		// /
 #define MACRO_SCANCODE_RShift 0x36		// Right Shift
 #define MACRO_SCANCODE_AstrP  0x37		// * Pad
+#define MACRO_SCANCODE_PrtSc  0x37		// Print Screen
 #define MACRO_SCANCODE_Alt    0x38		// Alt    
 #define MACRO_SCANCODE_Space  0x39		// Space  
 #define MACRO_SCANCODE_Caps   0x3A		// Caps   


### PR DESCRIPTION
Hello,
I thought that it would be good (more practical in certain circumstances) to resume the execution (return the control to the host OS) by pressing the same key that triggered BugChecker (PrtSc).
So this very small PR implement this "feature". This is just an alias to 'X'+Enter command or F5 hotkey.
Please feel free to ignore/close this PR if you don't like this behaviour ;)

Luca